### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/mishmish-dev/subcase/compare/v0.1.0...v0.1.1) - 2023-03-26
+
+### Other
+- nice

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "subcase"
 description = "Deduplicate unit test code in Rust without fixtures"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.60"
 authors = ["Mishmish Dev <mishmish@mishmish.dev>"]


### PR DESCRIPTION
## 🤖 New release
* `subcase`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/mishmish-dev/subcase/compare/v0.1.0...v0.1.1) - 2023-03-26

### Other
- nice
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).